### PR TITLE
VStream CLI - Channels Tail Events (WebSocket example)

### DIFF
--- a/examples/vstream-cli/package.json
+++ b/examples/vstream-cli/package.json
@@ -13,6 +13,8 @@
     "@commander-js/extra-typings": "^11.1.0",
     "@iarna/toml": "^2.2.5",
     "@inquirer/prompts": "^3.2.0",
+    "bufferutil": "^4.0.8",
+    "close-with-grace": "^1.2.0",
     "commander": "^11.1.0",
     "keytar": "^7.9.0",
     "node-fetch": "^3.3.2",
@@ -20,12 +22,14 @@
     "ospath": "^1.2.2",
     "prettyjson": "^1.2.5",
     "tiny-invariant": "^1.3.1",
+    "ws": "^8.14.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20.8.9",
     "@types/ospath": "^1.2.2",
     "@types/prettyjson": "^0.0.32",
+    "@types/ws": "^8.5.8",
     "esbuild": "^0.19.5",
     "typescript": "^5.2.2"
   }

--- a/examples/vstream-cli/pnpm-lock.yaml
+++ b/examples/vstream-cli/pnpm-lock.yaml
@@ -7,6 +7,9 @@ specifiers:
   '@types/node': ^20.8.9
   '@types/ospath': ^1.2.2
   '@types/prettyjson': ^0.0.32
+  '@types/ws': ^8.5.8
+  bufferutil: ^4.0.8
+  close-with-grace: ^1.2.0
   commander: ^11.1.0
   esbuild: ^0.19.5
   keytar: ^7.9.0
@@ -16,12 +19,15 @@ specifiers:
   prettyjson: ^1.2.5
   tiny-invariant: ^1.3.1
   typescript: ^5.2.2
+  ws: ^8.14.2
   zod: ^3.22.4
 
 dependencies:
   '@commander-js/extra-typings': 11.1.0_commander@11.1.0
   '@iarna/toml': 2.2.5
   '@inquirer/prompts': 3.2.0
+  bufferutil: 4.0.8
+  close-with-grace: 1.2.0
   commander: 11.1.0
   keytar: 7.9.0
   node-fetch: 3.3.2
@@ -29,12 +35,14 @@ dependencies:
   ospath: 1.2.2
   prettyjson: 1.2.5
   tiny-invariant: 1.3.1
+  ws: 8.14.2_bufferutil@4.0.8
   zod: 3.22.4
 
 devDependencies:
   '@types/node': 20.8.9
   '@types/ospath': 1.2.2
   '@types/prettyjson': 0.0.32
+  '@types/ws': 8.5.8
   esbuild: 0.19.5
   typescript: 5.2.2
 
@@ -392,6 +400,12 @@ packages:
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: false
 
+  /@types/ws/8.5.8:
+    resolution: {integrity: sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==}
+    dependencies:
+      '@types/node': 20.8.9
+    dev: true
+
   /ansi-escapes/4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -442,6 +456,14 @@ packages:
       ieee754: 1.2.1
     dev: false
 
+  /bufferutil/4.0.8:
+    resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
+    engines: {node: '>=6.14.2'}
+    requiresBuild: true
+    dependencies:
+      node-gyp-build: 4.6.1
+    dev: false
+
   /bundle-name/3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
     engines: {node: '>=12'}
@@ -473,6 +495,10 @@ packages:
   /cli-width/4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+    dev: false
+
+  /close-with-grace/1.2.0:
+    resolution: {integrity: sha512-Xga0jyAb4fX98u5pZAgqlbqHP8cHuy5M3Wto0k0L/36aP2C25Cjp51XfPw3Hz7dNC2L2/hF/PK/KJhO275L+VA==}
     dev: false
 
   /color-convert/2.0.1:
@@ -830,6 +856,11 @@ packages:
       formdata-polyfill: 4.0.10
     dev: false
 
+  /node-gyp-build/4.6.1:
+    resolution: {integrity: sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==}
+    hasBin: true
+    dev: false
+
   /npm-run-path/4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -1140,6 +1171,21 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: false
+
+  /ws/8.14.2_bufferutil@4.0.8:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dependencies:
+      bufferutil: 4.0.8
     dev: false
 
   /yallist/4.0.0:

--- a/examples/vstream-cli/src/commands/channels/get-channel-info.mts
+++ b/examples/vstream-cli/src/commands/channels/get-channel-info.mts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import { z } from "zod";
 import { channels } from "./index.mjs";
 import { requireSavedToken } from "../../utils/token.mjs";
-import { VSTREAM_URL } from "../../utils/constants.mjs";
+import { API_URL } from "../../utils/constants.mjs";
 import { FORMAT_OPTION, format } from "../../utils/format.mjs";
 
 channels
@@ -20,7 +20,7 @@ channels
         message: "Enter a channel ID",
       }));
 
-    const url = `${VSTREAM_URL}/channels/${channelId}/info`;
+    const url = `${API_URL}/channels/${channelId}/info`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token.access_token}`,

--- a/examples/vstream-cli/src/commands/channels/get-channel-metrics.mts
+++ b/examples/vstream-cli/src/commands/channels/get-channel-metrics.mts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import { z } from "zod";
 import { channels } from "./index.mjs";
 import { requireSavedToken } from "../../utils/token.mjs";
-import { VSTREAM_URL } from "../../utils/constants.mjs";
+import { API_URL } from "../../utils/constants.mjs";
 import { FORMAT_OPTION, format } from "../../utils/format.mjs";
 
 channels
@@ -20,7 +20,7 @@ channels
         message: "Enter a channel ID",
       }));
 
-    const url = `${VSTREAM_URL}/channels/${channelId}/metrics`;
+    const url = `${API_URL}/channels/${channelId}/metrics`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token.access_token}`,

--- a/examples/vstream-cli/src/commands/channels/get-channel.mts
+++ b/examples/vstream-cli/src/commands/channels/get-channel.mts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import { z } from "zod";
 import { channels } from "./index.mjs";
 import { requireSavedToken } from "../../utils/token.mjs";
-import { VSTREAM_URL } from "../../utils/constants.mjs";
+import { API_URL } from "../../utils/constants.mjs";
 import { FORMAT_OPTION, format } from "../../utils/format.mjs";
 
 channels
@@ -20,7 +20,7 @@ channels
         message: "Enter a channel ID",
       }));
 
-    const url = `${VSTREAM_URL}/channels/${channelId}`;
+    const url = `${API_URL}/channels/${channelId}`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token.access_token}`,

--- a/examples/vstream-cli/src/commands/channels/tail-events.mts
+++ b/examples/vstream-cli/src/commands/channels/tail-events.mts
@@ -1,0 +1,50 @@
+import { input } from "@inquirer/prompts";
+import closeWithGrace from "close-with-grace";
+import { WebSocket } from "ws";
+import { channels } from "./index.mjs";
+import { requireSavedToken } from "../../utils/token.mjs";
+import { EVENTS_URL } from "../../utils/constants.mjs";
+import { FORMAT_OPTION, format } from "../../utils/format.mjs";
+import { Agent } from "http";
+
+channels
+  .command("tail-events")
+  .description("subscribe to realtime channel events")
+  .option("-i, --channel-id <id>", "channel ID")
+  .addOption(FORMAT_OPTION)
+  .action(async (options) => {
+    const token = await requireSavedToken();
+
+    const channelId =
+      options.channelId ??
+      (await input({
+        message: "Enter a channel ID",
+      }));
+
+    const url = `${EVENTS_URL}/channels/${channelId}/events`;
+    const ws = new WebSocket(url, {
+      followRedirects: true,
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+      },
+    });
+
+    ws.on("error", console.error);
+
+    ws.on("open", function open() {
+      console.info(format(options.format, { message: "Connected" }));
+    });
+
+    ws.on("message", function message(data) {
+      const message = JSON.parse(data.toString("utf8"));
+      console.info(format(options.format, { event: message }));
+    });
+
+    closeWithGrace(
+      () =>
+        new Promise((resolve) => {
+          ws.close();
+          ws.on("close", resolve);
+        })
+    );
+  });

--- a/examples/vstream-cli/src/index.mts
+++ b/examples/vstream-cli/src/index.mts
@@ -5,5 +5,6 @@ import "./commands/login.mjs";
 import "./commands/channels/get-channel-info.mjs";
 import "./commands/channels/get-channel-metrics.mjs";
 import "./commands/channels/get-channel.mjs";
+import "./commands/channels/tail-events.mjs";
 
 program.parse();

--- a/examples/vstream-cli/src/utils/constants.mts
+++ b/examples/vstream-cli/src/utils/constants.mts
@@ -1,1 +1,3 @@
-export const VSTREAM_URL = process.env.VSTREAM_URL ?? "https://api.vstream.com";
+export const API_URL = process.env.API_URL ?? "https://api.vstream.com";
+export const EVENTS_URL =
+  process.env.EVENTS_URL ?? "https://events.vstream.com";

--- a/examples/vstream-cli/src/utils/discovery.mts
+++ b/examples/vstream-cli/src/utils/discovery.mts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { VSTREAM_URL } from "./constants.mjs";
+import { API_URL } from "./constants.mjs";
 
 export type DiscoveryResponse = z.infer<typeof DiscoveryResponse>;
 
@@ -11,7 +11,7 @@ const DiscoveryResponse = z.object({
 
 export async function getDiscovery() {
   try {
-    const discoveryUrl = `${VSTREAM_URL}/oidc/.well-known/openid-configuration`;
+    const discoveryUrl = `${API_URL}/oidc/.well-known/openid-configuration`;
     const response = await fetch(discoveryUrl).then((res) => res.json());
     return DiscoveryResponse.parse(response);
   } catch (error) {


### PR DESCRIPTION
```
Usage: vstream channels tail-events [options]

subscribe to realtime channel events

Options:
  -i, --channel-id <id>  channel ID
  -f, --format <format>  output format (choices: "pretty", "json", default: "pretty")
  -h, --help             display help for command
```