### PR TITLE
feat: Add `channels lookup-channel` and `videos lookup-video` commands to CLI

### DIFF
--- a/examples/vstream-cli/src/commands/channels/lookup-channel.mts
+++ b/examples/vstream-cli/src/commands/channels/lookup-channel.mts
@@ -1,0 +1,41 @@
+import { input } from "@inquirer/prompts";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { channels } from "./index.mjs";
+import { requireSavedToken } from "../../utils/token.mjs";
+import { API_URL } from "../../utils/constants.mjs";
+import { FORMAT_OPTION, format } from "../../utils/format.mjs";
+
+channels
+  .command("lookup-channel")
+  .description("look up a channel by its username")
+  .option("-u, --username <username>", "username")
+  .addOption(FORMAT_OPTION)
+  .action(async (options) => {
+    const token = await requireSavedToken();
+
+    const username =
+      options.username ??
+      (await input({
+        message: "Enter a username to look up",
+      }));
+
+    const url = new URL(`${API_URL}/channels/lookup`);
+    url.searchParams.set("username", username);
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+      },
+    });
+    if (response.status === 404) {
+      throw new Error("Channel not found");
+    }
+    if (!response.ok) {
+      throw new Error("Failed to look up channel");
+    }
+
+    const json = await response.json();
+    const data = z.object({ data: z.unknown() }).parse(json).data;
+
+    console.info(format(options.format, data));
+  });

--- a/examples/vstream-cli/src/commands/videos/index.mts
+++ b/examples/vstream-cli/src/commands/videos/index.mts
@@ -1,0 +1,3 @@
+import { program } from "../../program.mjs";
+
+export const videos = program.command("videos");

--- a/examples/vstream-cli/src/commands/videos/lookup-video.mts
+++ b/examples/vstream-cli/src/commands/videos/lookup-video.mts
@@ -1,0 +1,41 @@
+import { input } from "@inquirer/prompts";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { videos } from "./index.mjs";
+import { requireSavedToken } from "../../utils/token.mjs";
+import { API_URL } from "../../utils/constants.mjs";
+import { FORMAT_OPTION, format } from "../../utils/format.mjs";
+
+videos
+  .command("lookup-video")
+  .description("look up a video by its web ID")
+  .option("-i, --web-id <web-id>", "web ID")
+  .addOption(FORMAT_OPTION)
+  .action(async (options) => {
+    const token = await requireSavedToken();
+
+    const username =
+      options.webId ??
+      (await input({
+        message: "Enter a video web ID to look up",
+      }));
+
+    const url = new URL(`${API_URL}/videos/lookup`);
+    url.searchParams.set("webID", username);
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+      },
+    });
+    if (response.status === 404) {
+      throw new Error("Video not found");
+    }
+    if (!response.ok) {
+      throw new Error("Failed to look up video");
+    }
+
+    const json = await response.json();
+    const data = z.object({ data: z.unknown() }).parse(json).data;
+
+    console.info(format(options.format, data));
+  });

--- a/examples/vstream-cli/src/index.mts
+++ b/examples/vstream-cli/src/index.mts
@@ -5,6 +5,8 @@ import "./commands/login.mjs";
 import "./commands/channels/get-channel-info.mjs";
 import "./commands/channels/get-channel-metrics.mjs";
 import "./commands/channels/get-channel.mjs";
+import "./commands/channels/lookup-channel.mjs";
 import "./commands/channels/tail-events.mjs";
+import "./commands/videos/lookup-video.mjs";
 
 program.parse();


### PR DESCRIPTION
Lookup channel:

```
Usage: vstream channels lookup-channel [options]

look up a channel by its username

Options:
  -u, --username <username>  username
  -f, --format <format>      output format (choices: "pretty", "json", default: "pretty")
  -h, --help                 display help for command
```

Lookup video:

```
Usage: vstream videos lookup-video [options]

look up a video by its web ID

Options:
  -i, --web-id <web-id>  web ID
  -f, --format <format>  output format (choices: "pretty", "json", default: "pretty")
  -h, --help             display help for command
```