### PR TITLE
feat: Support public OAuth clients in addition to confidential clients

### DIFF
--- a/examples/vstream-cli/src/commands/login.mts
+++ b/examples/vstream-cli/src/commands/login.mts
@@ -69,6 +69,12 @@ function generateAuthUrl(
   authUrl.searchParams.append("client_id", config.client.client_id);
   authUrl.searchParams.append("scope", scopes.join(" "));
   authUrl.searchParams.append(
+    "claims",
+    JSON.stringify({
+      id_token: { picture: null, preferred_username: null, profile: null },
+    })
+  );
+  authUrl.searchParams.append(
     "redirect_uri",
     `http://localhost:${config.client.redirect_port}/`
   );

--- a/examples/vstream-cli/src/utils/config.mts
+++ b/examples/vstream-cli/src/utils/config.mts
@@ -9,7 +9,7 @@ export type Config = z.infer<typeof Config>;
 const Config = z.object({
   client: z.object({
     client_id: z.string(),
-    client_secret: z.string(),
+    client_secret: z.string().optional(),
     redirect_port: z.number().int(),
   }),
 });


### PR DESCRIPTION
This PR allows you to configure and log in with either an OAuth confidential client (with a `client_secret`) or an OAuth public client (no `client_secret`)

```
Usage: vstream configure [options]

configure your VStream app client credentials

Options:
  -t, --client-type <type>      OAuth client type (choices: "confidential", "public")
  -c, --client-id <id>          OAuth client ID
  -s, --client-secret <secret>  OAuth client secret
  -p, --port <number>           OAuth redirect port
  -h, --help                    display help for command
```