### PR TITLE
feat: Support both header-based and queryparam-based WebSocket auth

### DIFF
--- a/examples/vstream-cli/src/commands/channels/tail-events.mts
+++ b/examples/vstream-cli/src/commands/channels/tail-events.mts
@@ -1,16 +1,23 @@
-import { input } from "@inquirer/prompts";
+import { Option } from "@commander-js/extra-typings";
+import { input, select } from "@inquirer/prompts";
 import closeWithGrace from "close-with-grace";
 import { WebSocket } from "ws";
+import { z } from "zod";
 import { channels } from "./index.mjs";
-import { requireSavedToken } from "../../utils/token.mjs";
-import { EVENTS_URL } from "../../utils/constants.mjs";
+import { SavedToken, requireSavedToken } from "../../utils/token.mjs";
+import { API_URL, EVENTS_URL } from "../../utils/constants.mjs";
 import { FORMAT_OPTION, format } from "../../utils/format.mjs";
-import { Agent } from "http";
 
 channels
   .command("tail-events")
   .description("subscribe to realtime channel events")
   .option("-i, --channel-id <id>", "channel ID")
+  .addOption(
+    new Option(
+      "-a, --auth-method <method>",
+      "how to authenticate the request"
+    ).choices(["header", "queryparam"] as const)
+  )
   .addOption(FORMAT_OPTION)
   .action(async (options) => {
     const token = await requireSavedToken();
@@ -21,21 +28,57 @@ channels
         message: "Enter a channel ID",
       }));
 
+    const authMethod = z.enum(["header", "queryparam"]).parse(
+      options.authMethod ??
+        (await select({
+          message: "Select an authentication method",
+          choices: [
+            {
+              value: "header",
+              name: "Authorization header",
+              description:
+                "The access token is sent as a bearer token in the Authorization header",
+            },
+            {
+              value: "queryparam",
+              name: "Query parameter",
+              description:
+                "A single-use connection token is sent as a query parameter",
+            },
+          ],
+        }))
+    );
+
     const url = `${EVENTS_URL}/channels/${channelId}/events`;
-    const ws = new WebSocket(url, {
-      followRedirects: true,
-      headers: {
-        Authorization: `Bearer ${token.access_token}`,
-      },
+    const ws =
+      authMethod === "header"
+        ? createWebSocketWithHeaderAuth(url, token)
+        : await createWebSocketWithQueryParamAuth(url, token);
+
+    ws.on("error", (err) => {
+      console.error(err);
     });
 
-    ws.on("error", console.error);
-
-    ws.on("open", function open() {
+    let pingTimeout: NodeJS.Timeout;
+    ws.on("open", () => {
       console.info(format(options.format, { message: "Connected" }));
+
+      pingTimeout = setInterval(() => {
+        // console.info(format(options.format, { message: "Ping" }));
+        // ws.ping();
+      }, 10000);
     });
 
-    ws.on("message", function message(data) {
+    ws.on("close", () => {
+      clearInterval(pingTimeout);
+      console.info(format(options.format, { message: "Disconnected" }));
+    });
+
+    ws.on("pong", () => {
+      console.info(format(options.format, { message: "Pong" }));
+    });
+
+    ws.on("message", (data) => {
       const message = JSON.parse(data.toString("utf8"));
       console.info(format(options.format, { event: message }));
     });
@@ -48,3 +91,65 @@ channels
         })
     );
   });
+
+/**
+ * Creates a WebSocket which authenticates using an access token in the Authorization
+ * header.
+ */
+function createWebSocketWithHeaderAuth(url: string, savedToken: SavedToken) {
+  const ws = new WebSocket(url, {
+    followRedirects: true,
+    headers: {
+      Authorization: `Bearer ${savedToken.access_token}`,
+    },
+  });
+
+  return ws;
+}
+
+/**
+ * Creates a WebSocket which authenticates using a single-use connection token
+ * in a query parameter.
+ */
+async function createWebSocketWithQueryParamAuth(
+  baseUrl: string,
+  savedToken: SavedToken
+) {
+  const connectionToken = await getConnectionToken(savedToken);
+  const url = new URL(baseUrl);
+  url.searchParams.set("authorization", connectionToken);
+  const ws = new WebSocket(url.toString(), {
+    followRedirects: true,
+  });
+
+  return ws;
+}
+
+/**
+ * Gets a single-use connection token which can be used to connect to the PubSub WebSocket API
+ * via a query parameter. This is useful for clients that cannot set headers, such as browser-based
+ * clients.
+ */
+async function getConnectionToken(token: SavedToken) {
+  const url = `${API_URL}/events/connect`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+    },
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error("Failed to get a connection token");
+  }
+
+  const json = await response.json();
+  const result = z
+    .object({ data: z.object({ token: z.string() }) })
+    .safeParse(json);
+
+  if (!result.success) {
+    throw new Error("Unexpected response from server");
+  }
+
+  return result.data.data.token;
+}


### PR DESCRIPTION
This PR adds a new `--auth-method` argument to the `tail-events` command, which can take either `header` or `queryparam` as a value.

The `header` auth method sends an access token directly as a bearer token in the `Authorization` header.

The `queryparam` auth method first exchanges the access token for a short-lived, single-use "connection token" which is sent as an `authorization` query param on the WebSocket connection request. This method is useful for browser-based clients which do not have access to setting the `Authorization` header when connecting to a websocket.

```
Usage: vstream channels tail-events [options]

subscribe to realtime channel events

Options:
  -i, --channel-id <id>       channel ID
  -a, --auth-method <method>  how to authenticate the request (choices: "header", "queryparam")
  -f, --format <format>       output format (choices: "pretty", "json", default: "pretty")
  -h, --help                  display help for command
```