### PR TITLE
feat: Support requesting OIDC claims and show the parsed ID Token on login

### DIFF
--- a/examples/vstream-cli/package.json
+++ b/examples/vstream-cli/package.json
@@ -16,6 +16,7 @@
     "bufferutil": "^4.0.8",
     "close-with-grace": "^1.2.0",
     "commander": "^11.1.0",
+    "jose": "^5.1.3",
     "keytar": "^7.9.0",
     "node-fetch": "^3.3.2",
     "open": "^9.1.0",

--- a/examples/vstream-cli/pnpm-lock.yaml
+++ b/examples/vstream-cli/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   close-with-grace: ^1.2.0
   commander: ^11.1.0
   esbuild: ^0.19.5
+  jose: ^5.1.3
   keytar: ^7.9.0
   node-fetch: ^3.3.2
   open: ^9.1.0
@@ -29,6 +30,7 @@ dependencies:
   bufferutil: 4.0.8
   close-with-grace: 1.2.0
   commander: 11.1.0
+  jose: 5.1.3
   keytar: 7.9.0
   node-fetch: 3.3.2
   open: 9.1.0
@@ -778,6 +780,10 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: false
+
+  /jose/5.1.3:
+    resolution: {integrity: sha512-GPExOkcMsCLBTi1YetY2LmkoY559fss0+0KVa6kOfb2YFe84nAM7Nm/XzuZozah4iHgmBGrCOHL5/cy670SBRw==}
     dev: false
 
   /keytar/7.9.0:

--- a/examples/vstream-cli/src/utils/discovery.mts
+++ b/examples/vstream-cli/src/utils/discovery.mts
@@ -5,8 +5,9 @@ export type DiscoveryResponse = z.infer<typeof DiscoveryResponse>;
 
 const DiscoveryResponse = z.object({
   authorization_endpoint: z.string().url(),
-  token_endpoint: z.string().url(),
+  claims_supported: z.array(z.string()),
   scopes_supported: z.array(z.string()),
+  token_endpoint: z.string().url(),
 });
 
 export async function getDiscovery() {

--- a/examples/vstream-cli/src/utils/token.mts
+++ b/examples/vstream-cli/src/utils/token.mts
@@ -10,6 +10,7 @@ const TokenResponse = z.object({
   access_token: z.string(),
   token_type: z.string(),
   expires_in: z.number(),
+  id_token: z.string().optional(),
   refresh_token: z.string().optional(),
   scope: z.string(),
 });


### PR DESCRIPTION
This PR adds the ability to request OpenID Connect claims via the `login` command if the `openid` scope is also requested. The claims will be requested for both the `userinfo` endpoint and the `id_token`, and the claims will be shown after login.